### PR TITLE
arm: hummingboard: Type for i2c2 status

### DIFF
--- a/arch/arm/boot/dts/imx6dl-hummingboard.dts
+++ b/arch/arm/boot/dts/imx6dl-hummingboard.dts
@@ -177,7 +177,7 @@
 	clock-frequency = <100000>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_i2c2_2>;
-	status = "okay";
+	status = "disable";
 };
 
 &iomuxc {


### PR DESCRIPTION
This is disabled for now because enabling it conflicts with the
hdmi mfd driver.
Same patch as for cubox-i in 5d2dc71e
