### PR TITLE
Enable video output using limited color range

### DIFF
--- a/drivers/video/mxc/mxc_hdmi.c
+++ b/drivers/video/mxc/mxc_hdmi.c
@@ -702,7 +702,7 @@ static void hdmi_video_csc(struct mxc_hdmi *hdmi)
 {
 	int color_depth = 0;
 	int interpolation = HDMI_CSC_CFG_INTMODE_DISABLE;
-	int decimation = 0;
+	int decimation = HDMI_CSC_CFG_DECMODE_DISABLE;
 	u8 val;
 
 	/* YCC422 interpolation to 444 mode */

--- a/drivers/video/mxc/mxc_hdmi.c
+++ b/drivers/video/mxc/mxc_hdmi.c
@@ -493,8 +493,10 @@ static void hdmi_video_sample(struct mxc_hdmi *hdmi)
 
 static int isColorSpaceConversion(struct mxc_hdmi *hdmi)
 {
-	return (hdmi->hdmi_data.enc_in_format !=
-		hdmi->hdmi_data.enc_out_format);
+	return (hdmi->hdmi_data.enc_in_format != hdmi->hdmi_data.enc_out_format) ||
+		(hdmi->hdmi_data.enc_out_format == RGB &&
+		  ((hdmi->hdmi_data.rgb_quant_range == HDMI_FC_AVICONF2_RGB_QUANT_LIMITED_RANGE) ||
+		   (hdmi->hdmi_data.rgb_quant_range == HDMI_FC_AVICONF2_RGB_QUANT_DEFAULT && hdmi->vic > 1)));
 }
 
 static int isColorSpaceDecimation(struct mxc_hdmi *hdmi)
@@ -523,7 +525,25 @@ static void update_csc_coeffs(struct mxc_hdmi *hdmi)
 
 	if (isColorSpaceConversion(hdmi)) { /* csc needed */
 		if (hdmi->hdmi_data.enc_out_format == RGB) {
-			if (hdmi->hdmi_data.colorimetry == eITU601) {
+			if (hdmi->hdmi_data.enc_in_format == RGB) {
+				csc_coeff[0][0] = 0x1b80;
+				csc_coeff[0][1] = 0x0000;
+				csc_coeff[0][2] = 0x0000;
+				csc_coeff[0][3] = 0x0020;
+
+				csc_coeff[1][0] = 0x0000;
+				csc_coeff[1][1] = 0x1b80;
+				csc_coeff[1][2] = 0x0000;
+				csc_coeff[1][3] = 0x0020;
+
+				csc_coeff[2][0] = 0x0000;
+				csc_coeff[2][1] = 0x0000;
+				csc_coeff[2][2] = 0x1b80;
+				csc_coeff[2][3] = 0x0020;
+
+				csc_scale = 1;
+				coeff_selected = true;
+			} else if (hdmi->hdmi_data.colorimetry == eITU601) {
 				csc_coeff[0][0] = 0x2000;
 				csc_coeff[0][1] = 0x6926;
 				csc_coeff[0][2] = 0x74fd;
@@ -1770,7 +1790,7 @@ static void mxc_hdmi_enable_video_path(struct mxc_hdmi *hdmi)
 	hdmi_writeb(clkdis, HDMI_MC_CLKDIS);
 
 	/* Enable csc path */
-	if (isColorSpaceConversion(hdmi)) {
+	if (isColorSpaceConversion(hdmi) && !hdmi->hdmi_data.video_mode.mDVI) {
 		clkdis &= ~HDMI_MC_CLKDIS_CSCCLK_DISABLE;
 		hdmi_writeb(clkdis, HDMI_MC_CLKDIS);
 	}


### PR DESCRIPTION
Currently, the RGB output always uses full range (0..255). Commit 9119f4982209edf12dee44240bcfaa52fba2b4d3 adds the ability to indicate this to the sink (i.e the TV) by setting the corresponding 'Q' bits in  byte 3 of the AVI info frame. However, these bits are only recognized by sinks that conform to CEA-861D, which appears to be the base for HDMI 1.3. Older TVs and even some not so old Sony Bravia models do not interpret this information and therefore still show wrong colors. This patch adds the ability to really force the output to limited color range (16..235) by using the on-chip color space converter. Even though the configuration options ('default', 'limited' and 'full') stay the same, the behavior is now  the following:

| mode | video output | color space conversion |
| --- | --- | --- |
| full | range 0..255, indicated via AVI info frame bits Q1,Q0 = 1,0 | bypassed |
| limited | range 16..235, indicated via AVI info frame Q1,Q0 = 0,1 | enabled |
| default | range 16..235 for CEA modes except 640x480p (VGA), range 0..255 for non-CEA modes as well as VGA, Q1,Q0 = 0,0 | when needed |

A fully HDMI.13 compatible TV should show no visual difference when switching between these three modes. However, the SoC might use less power when the color space converter is not used. In DVI mode no color space conversion is performed and output is always in full range.
